### PR TITLE
Adding a mkdirs() to create directories for nested source directories.

### DIFF
--- a/src/main/java/com/odiago/maven/plugins/soy/CompileMojo.java
+++ b/src/main/java/com/odiago/maven/plugins/soy/CompileMojo.java
@@ -161,6 +161,10 @@ public class CompileMojo extends AbstractMojo {
     }
     for (int i = 0; i < inputFilenames.length; i++) {
       File outputFile = new File(mOutputDirectory, inputFilenames[i] + ".js");
+      File parent = outputFile.getParentFile();
+      if(!parent.exists() && !parent.mkdirs()){
+        throw new IllegalStateException("Couldn't create dir: " + parent);
+      }
       getLog().info("Writing compiled soy: " + outputFile);
       Writer writer = null;
       try {

--- a/src/main/java/com/odiago/maven/plugins/soy/CompileMojo.java
+++ b/src/main/java/com/odiago/maven/plugins/soy/CompileMojo.java
@@ -20,6 +20,7 @@ package com.odiago.maven.plugins.soy;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.IllegalStateException;
 import java.io.Writer;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Currently any source paths fail silently when trying to write to a nested location. This patch ensures a parent directory.
